### PR TITLE
remove unnecessary dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
     "sharkdown": "sharkdown"
   },
   "dependencies": {
-    "expect.js": "~0.2.0",
     "split": "~0.2.10",
-    "stream-spigot": "~2.1.2",
-    "through": "~2.3.4",
     "minimist": "0.0.5",
     "cardinal": "~0.4.2"
   },


### PR DESCRIPTION
I'm trying to remove expect.js from my project and noticed it was being installed by this package (transitive dep of mapbox-gl)